### PR TITLE
Improve name handling

### DIFF
--- a/src/GDMENUCardManager.Core/GdItem.cs
+++ b/src/GDMENUCardManager.Core/GdItem.cs
@@ -9,7 +9,7 @@ namespace GDMENUCardManager.Core
 
     public sealed class GdItem : INotifyPropertyChanged
     {
-        private const int namemaxlen = 40;
+        private const int namemaxlen = 39;
 
         public string Guid { get; set; }
 

--- a/src/GDMENUCardManager.Core/GdItem.cs
+++ b/src/GDMENUCardManager.Core/GdItem.cs
@@ -33,7 +33,7 @@ namespace GDMENUCardManager.Core
                 {
                     if (_Name.Length > namemaxlen)
                         _Name = _Name.Substring(0, namemaxlen);
-                    _Name = Helper.RemoveDiacritics(_Name).ToUpperInvariant().Trim();
+                    _Name = Helper.RemoveDiacritics(_Name).Trim();
                 }
 
                 RaisePropertyChanged();


### PR DESCRIPTION
This updates the name handling in two ways;

1. It updates the maximum length to 39 as discussed in #13; I've tested this repeatedly and it's consistently the true limit
2. Names are no longer transformed to uppercase, as GDMenu can handle mixed case titles just fine

Fixes #13